### PR TITLE
update elasticsearch and remove python onbuild dep

### DIFF
--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -1,2 +1,7 @@
-FROM python:2-onbuild
+FROM python:2
+
+WORKDIR /usr/src/app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
 CMD ["celery", "-A", "ingest.backend", "worker", "--loglevel=info"]

--- a/Dockerfile.elastic
+++ b/Dockerfile.elastic
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.2
 ADD elasticsearch.yml /usr/share/elasticsearch/config/
 USER root
 RUN chown elasticsearch:elasticsearch config/elasticsearch.yml


### PR DESCRIPTION
### Description

This removes the `python:2-onbuild` dependency for the celery docker image and updates elasticsearch to 5.6.2
### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
